### PR TITLE
Link screenshot in README to actual website

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Literature suggestions per subsection are in alphabetical order.
 The website relies on the IEEE reference format.
 Pull requests or issues are welcome!
 
-![Screenshot](./public/img/screenshot.png "Screenshot")
+[![Screenshot](./public/img/screenshot.png "Screenshot")](https://xjreb.github.io/swe-research-methods/)


### PR DESCRIPTION
I don't know about anyone else, but whenever I want to go to the actual list via the GitHub repo, I try to do so by clicking on the screenshot, only to then unexpectedly see a larger resolution screenshot. Nothing too critical, but maybe others prefer the link to the actual website too :)